### PR TITLE
Fix Codacy review - ImageService #73

### DIFF
--- a/src/Controller/TrickController.php
+++ b/src/Controller/TrickController.php
@@ -124,7 +124,8 @@ class TrickController extends AbstractController
         ImageRepository $imageRepository,
         VideoService $videoService,
         EntityManagerInterface $entityManager,
-        SluggerInterface $slugger
+        SluggerInterface $slugger,
+        FileSystem $filesystem
     ): Response
     {
         $form = $this->createForm(TrickType::class, $trick);
@@ -132,6 +133,7 @@ class TrickController extends AbstractController
             $this->getParameter('images_directory'),
             $imageRepository,
             $entityManager,
+            $filesystem,
             $trick);
 
         $form->handleRequest($request);

--- a/src/Service/ImageService.php
+++ b/src/Service/ImageService.php
@@ -6,6 +6,7 @@ use App\Entity\Image;
 use App\Entity\Trick;
 use App\Repository\ImageRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ImageService
@@ -13,17 +14,20 @@ class ImageService
     private string $targetDirectory;
     private ImageRepository $imageRepository;
     private EntityManagerInterface $entityManager;
+    private Filesystem $filesystem;
     private Trick $trick;
 
     public function __construct(
         $targetDirectory,
         ImageRepository $imageRepository,
         EntityManagerInterface $entityManager,
+        Filesystem $filesystem,
         Trick $trick)
     {
         $this->targetDirectory = $targetDirectory;
         $this->imageRepository = $imageRepository;
         $this->entityManager = $entityManager;
+        $this->filesystem = $filesystem;
         $this->trick = $trick;
     }
 
@@ -62,14 +66,14 @@ class ImageService
     private function checkFeaturedImage(): void
     {
         // Vérification si image mise en avant déjà présente pour cette figure
-        $checkPresentFeaturedImage = $this->imageRepository->findOneBy(['tricks' => $this->trick->getId(), 'featuredImage' => true]);
+        $checkFeaturedImage = $this->imageRepository->findOneBy(['tricks' => $this->trick->getId(), 'featuredImage' => true]);
 
         // Si oui on supprime cette image
-        if ($checkPresentFeaturedImage) {
+        if ($checkFeaturedImage) {
             // On supprime le fichier
-            unlink($this->targetDirectory.'/'.$checkPresentFeaturedImage->getName());
+            $this->filesystem->remove($this->targetDirectory.'/'.$checkFeaturedImage->getName());
             // On supprime de la base de données
-            $this->entityManager->remove($checkPresentFeaturedImage);
+            $this->entityManager->remove($checkFeaturedImage);
             $this->entityManager->flush();
         }
     }


### PR DESCRIPTION
ImageService
------------------
-  Avoid excessively long variable names like $checkPresentFeaturedImage. Keep variable name length under 20.
-  The use of function unlink() is discouraged